### PR TITLE
closes #133

### DIFF
--- a/context-core/pom.xml
+++ b/context-core/pom.xml
@@ -75,6 +75,13 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
             <version>${cxf.version}</version>
+            <exclusions>
+                <!--Use JDK-supplied parser - see https://issues.apache.org/jira/projects/JENA/issues/JENA-2331 -->
+                <exclusion>
+                    <groupId>com.fasterxml.woodstox</groupId>
+                    <artifactId>woodstox-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>


### PR DESCRIPTION
Remove woodstox as a dependency so that cxf and jena use
JDK-supplied XML parser instead.